### PR TITLE
Bump version to v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ The Dialogue Maker is an open-source plugin for creating RPG-like dialogue boxes
 * Responsive dialogue editor
 * Trigger dialogue with proximity regions and ClickDetectors
 * Prioritize your dialogue with conditions and message stacking
-* Run synchronous and asynchronous functions before and after dialogue starts
+* Run functions before and after a message
 * Impose dialogue timeouts
 * Embed variables that are customizable throughout the conversation
 * Add responses for the player to add interactivity to the conversation
-* Add dialogue redirects and make the conversation flow efficient
+* Add dialogue redirects
+* Customize themes per NPC and per screen size
+* Add message pauses
 
 ## Where can I get it?
 You can either get [the version Beastslash updates at the Roblox Library](https://www.roblox.com/library/4930928141/Dialogue-Maker-Beta) or you can build your own version by using the scripts in this repository.
@@ -26,10 +28,10 @@ Sure! If you feel like that the Dialogue Maker can be improved for everyone, jus
 * [**Christian "Sudobeast" Toney**](https://twitter.com/Sudobeast) - Project Manager and Lead Programmer
 * [**BHickey94**](https://github.com/BHickey94) - Code Contributor
 * [**GAVsi115**](https://devforum.roblox.com/u/gavsi115/summary) - Code Contributor and Bug Reporter
+* [**extravent3**](https://devforum.roblox.com/u/extravent3/summary) - Issue Sponsor and Bug Reporter
 * [**ruax2891**](https://twitter.com/ruax2891) - QA Tester
 * [**InkyTheBlue**](https://twitter.com/InkyTheBlueDerg) - QA Tester
 * [**BeatArcade**](https://www.roblox.com/users/2893686241/profile) - Bug Reporter
 * [**joshuajon**](https://github.com/joshuajon) - Bug Reporter
 * [**LordMerc**](https://devforum.roblox.com/u/lordmerc/summary) - Bug Reporter
 * [**thomkok13**](https://devforum.roblox.com/u/thomkok13/summary) - Bug Reporter
-* [**extravent3**](https://devforum.roblox.com/u/extravent3/summary) - Bug Reporter

--- a/client/DialogueClientScript.lua
+++ b/client/DialogueClientScript.lua
@@ -28,30 +28,26 @@ for _, npc in ipairs(NPCDialogue) do
     
     -- Get speech bubble settings.
     local DialogueSettings = require(npc.DialogueContainer.Settings);
-    local SpeechBubbleSettingsIsTable = typeof(DialogueSettings.SpeechBubble) == "table";
-    local SpeechBubbleEnabled = DialogueSettings.SpeechBubbleEnabled or (SpeechBubbleSettingsIsTable and DialogueSettings.SpeechBubble.Enabled);
-    local SpeechBubblePart = DialogueSettings.SpeechBubblePart or (SpeechBubbleSettingsIsTable and DialogueSettings.SpeechBubble.BasePart);
+    local SpeechBubbleEnabled = DialogueSettings.SpeechBubble.Enabled;
+    local SpeechBubblePart = DialogueSettings.SpeechBubble.BasePart;
     
     -- Get prompt region settings.
-    local PromptRegionSettingsIsTable = typeof(DialogueSettings.PromptRegion) == "table";
-    local PromptRegionEnabled = DialogueSettings.PromptRegionEnabled or (PromptRegionSettingsIsTable and DialogueSettings.PromptRegion.Enabled);
-    local PromptRegionPart = DialogueSettings.PromptRegionPart or (PromptRegionSettingsIsTable and DialogueSettings.PromptRegion.Part);
+    local PromptRegionEnabled = DialogueSettings.PromptRegion.Enabled;
+    local PromptRegionPart = DialogueSettings.PromptRegion.Part;
     
     -- Get proximity prompt settings.
-    local ProximityPromptSettingsIsTable = typeof(DialogueSettings.ProximityPrompt) == "table";
-    local ProximityPromptEnabled = DialogueSettings.ProximityPromptEnabled or (ProximityPromptSettingsIsTable and DialogueSettings.ProximityPrompt.Enabled);
-    local ProximityPromptLocation = DialogueSettings.ProximityPromptLocation or (ProximityPromptSettingsIsTable and DialogueSettings.ProximityPrompt.Location);
-    local ProximityPromptAutoCreate = DialogueSettings.AutomaticallyCreateProximityPrompt or (ProximityPromptSettingsIsTable and DialogueSettings.ProximityPrompt.AutoCreate);
-    local ProximityPromptActivationDistance = DialogueSettings.ProximityPromptActivationDistance or (ProximityPromptSettingsIsTable and DialogueSettings.ProximityPrompt.MaxActivationDistance);
-    local ProximityPromptHoldDuration = DialogueSettings.ProximityPromptHoldDuration or (ProximityPromptSettingsIsTable and DialogueSettings.ProximityPrompt.HoldDuration);
-    local ProximityPromptRequiresLineOfSight = DialogueSettings.ProximityPromptRequiresLineOfSight or (ProximityPromptSettingsIsTable and DialogueSettings.ProximityPrompt.RequiresLineOfSight);
+    local ProximityPromptEnabled = DialogueSettings.ProximityPrompt.Enabled;
+    local ProximityPromptLocation = DialogueSettings.ProximityPrompt.Location;
+    local ProximityPromptAutoCreate = DialogueSettings.ProximityPrompt.AutoCreate;
+    local ProximityPromptActivationDistance = DialogueSettings.ProximityPrompt.MaxActivationDistance;
+    local ProximityPromptHoldDuration = DialogueSettings.ProximityPrompt.HoldDuration;
+    local ProximityPromptRequiresLineOfSight = DialogueSettings.ProximityPrompt.RequiresLineOfSight;
     
     -- Get click detector settings.
-    local ClickDetectorSettingsIsTable = typeof(DialogueSettings.ClickDetector) == "table";
-    local ClickDetectorEnabled = DialogueSettings.ClickDetectorEnabled or (ClickDetectorSettingsIsTable and DialogueSettings.ClickDetector.Enabled);
-    local ClickDetectorLocation = DialogueSettings.ClickDetectorLocation or (ClickDetectorSettingsIsTable and DialogueSettings.ClickDetector.Location);
-    local ClickDetectorAutoCreate = DialogueSettings.AutomaticallyCreateClickDetector or (ClickDetectorSettingsIsTable and DialogueSettings.ClickDetector.AutoCreate);
-    local ClickDetectorActivationDistance = DialogueSettings.DetectorActivationDistance or (ClickDetectorSettingsIsTable and DialogueSettings.ClickDetector.ActivationDistance);
+    local ClickDetectorEnabled = DialogueSettings.ClickDetector.Enabled;
+    local ClickDetectorLocation = DialogueSettings.ClickDetector.Location;
+    local ClickDetectorAutoCreate = DialogueSettings.ClickDetector.AutoCreate;
+    local ClickDetectorActivationDistance = DialogueSettings.ClickDetector.ActivationDistance;
     
     -- Now it's time to set up speech bubbles.
     if SpeechBubbleEnabled and SpeechBubblePart then

--- a/client/DialogueClientScript.lua
+++ b/client/DialogueClientScript.lua
@@ -111,14 +111,6 @@ for _, npc in ipairs(NPCDialogue) do
         ProximityPrompt.MaxActivationDistance = ProximityPromptActivationDistance;
         ProximityPrompt.HoldDuration = ProximityPromptHoldDuration;
         ProximityPrompt.RequiresLineOfSight = ProximityPromptRequiresLineOfSight;
-
-        -- TODO: Remove in v4.0.0
-        if typeof(DialogueSettings.ProximityPrompt) == "table" then
-          ProximityPrompt.GamepadKeyCode = DialogueSettings.ProximityPrompt.GamepadKeyCode;
-          ProximityPrompt.KeyboardKeyCode = DialogueSettings.ProximityPrompt.KeyboardKeyCode;
-          ProximityPrompt.ObjectText = DialogueSettings.ProximityPrompt.ObjectText;
-        end;
-
         ProximityPrompt.Parent = npc;
         ProximityPromptLocation = ProximityPrompt;
 

--- a/client/DialogueClientScript/API/Dialogue.lua
+++ b/client/DialogueClientScript/API/Dialogue.lua
@@ -611,7 +611,7 @@ function DialogueModule.ReadDialogue(npc: Model)
 
           end;
 
-          ResponseContainer.CanvasSize = UDim2.new(0, ResponseContainer.CanvasSize.X, 0, ResponseContainer.UIListLayout.AbsoluteContentSize.Y);
+          ResponseContainer.CanvasSize = UDim2.new(0, ResponseContainer.CanvasSize.X.Offset, 0, ResponseContainer.UIListLayout.AbsoluteContentSize.Y);
           ThemeDialogueContainer.ResponseContainer.Visible = true;
 
         end;

--- a/client/DialogueClientScript/API/Dialogue.lua
+++ b/client/DialogueClientScript/API/Dialogue.lua
@@ -270,18 +270,18 @@ function DialogueModule.ReadDialogue(npc: Model)
     local NPCPrimaryPart = npc.PrimaryPart;
     local DialogueContainer = npc:FindFirstChild("DialogueContainer");
     local DialogueSettings = require(DialogueContainer.Settings);
-    local DialogueGui = API.GUI.CreateNewDialogueGui(DialogueSettings.Theme or (DialogueSettings.General and DialogueSettings.General.ThemeName));
-    local FreezePlayer = DialogueSettings.FreezePlayer or (DialogueSettings.General and DialogueSettings.General.FreezePlayer);
-    local MaxConversationDistance = DialogueSettings.MaximumConversationDistance or (DialogueSettings.General and DialogueSettings.General.MaxConversationDistance);
-    local EndConversationIfOutOfDistance = DialogueSettings.EndConversationIfOutOfDistance or (DialogueSettings.General and DialogueSettings.General.EndConversationIfOutOfDistance);
-    local NPCName = DialogueSettings.Name or (DialogueSettings.General and DialogueSettings.General.NPCName);
-    local FitName = DialogueSettings.General and DialogueSettings.General.FitName;
-    local TextBoundsOffset = (DialogueSettings.General and DialogueSettings.General.TextBoundsOffset) or 30;
-    local AllowPlayerToSkipDelay = DialogueSettings.AllowPlayerToSkipDelay or (DialogueSettings.General and DialogueSettings.General.AllowPlayerToSkipDelay);
-    local LetterDelay = DialogueSettings.LetterDelay or (DialogueSettings.General and DialogueSettings.General.LetterDelay);
-    local TimeoutEnabled = DialogueSettings.TimeoutEnabled or (DialogueSettings.General and DialogueSettings.General.TimeoutEnabled);
-    local ConversationTimeoutInSeconds = DialogueSettings.ConversationTimeoutInSeconds or (DialogueSettings.General and DialogueSettings.General.ConversationTimeoutInSeconds);
-    local WaitForResponse = DialogueSettings.WaitForResponse or (DialogueSettings.General and DialogueSettings.General.WaitForResponse);
+    local DialogueGui = API.GUI.CreateNewDialogueGui(DialogueSettings.General.ThemeName);
+    local FreezePlayer = DialogueSettings.General.FreezePlayer;
+    local MaxConversationDistance = DialogueSettings.General.MaxConversationDistance;
+    local EndConversationIfOutOfDistance = DialogueSettings.General.EndConversationIfOutOfDistance;
+    local NPCName = DialogueSettings.General.NPCName;
+    local FitName = DialogueSettings.General.FitName;
+    local TextBoundsOffset = DialogueSettings.General.TextBoundsOffset or 30;
+    local AllowPlayerToSkipDelay = DialogueSettings.General.AllowPlayerToSkipDelay;
+    local LetterDelay = DialogueSettings.General.LetterDelay;
+    local TimeoutEnabled = DialogueSettings.General.TimeoutEnabled;
+    local ConversationTimeoutInSeconds = DialogueSettings.General.ConversationTimeoutInSeconds;
+    local WaitForResponse = DialogueSettings.General.WaitForResponse;
     local ResponseContainer, ResponseTemplate, ClickSound, ClickSoundEnabled, OldDialogueGui;
 
     -- If necessary, freeze the player

--- a/client/DialogueClientScript/API/Dialogue.lua
+++ b/client/DialogueClientScript/API/Dialogue.lua
@@ -79,63 +79,146 @@ function DialogueModule.ClearResponses(responseContainer: Folder)
 
 end;
 
-function DialogueModule.DivideTextToFitBox(text: string, textContainer: Frame): {{[number]: string}?}
+function DialogueModule.DivideTextToFitBox(text: string, textContainer: Frame): {[number]: string}
 
-  local Line = textContainer:FindFirstChild("Line"):Clone();
+  -- Make sure we have a TextLabel named "Line".
+  local OriginalLine: TextLabel? = textContainer:FindFirstChild("Line") :: TextLabel;
+  assert(OriginalLine, "Line not found in NPCTextContainer.");
+  
+  -- Clone the TextLabel.
+  local Line: TextLabel = OriginalLine:Clone();
   Line.Name = "LineTest";
   Line.Visible = false;
   Line.Parent = textContainer;
-  Line.Text = "";
+  
+  -- Determine rich text indices.
+  local RichTextTagIndices: {
+    [number]: {
+      Name: string;
+      Attributes: string?;
+      StartOffset: number;
+      EndOffset: number?;
+    }
+  } = {};
+  local OpenTagIndices: {[number]: number} = {};
+  local textCopy = text;
+  local tagPattern = "<[^<>]->";
+  local Pointer = 1;
+  for tag in textCopy:gmatch(tagPattern) do
+    
+    -- Get the tag name and attributes.
+    local TagText = tag:match("<([^<>]-)>");
+    local FirstSpaceIndex = TagText:find(" ");
+    local TagTextLength = TagText:len();
+    local Name = TagText:sub(1, (FirstSpaceIndex and FirstSpaceIndex - 1) or TagTextLength);
+    if Name:sub(1, 1) == "/" then
 
-  local Divisions = {};
-  local Page = 1;
-  for index, word in ipairs(text:split(" ")) do
+      for _, index in ipairs(OpenTagIndices) do
+        
+        if RichTextTagIndices[index].Name == Name:sub(2) then
+          
+          -- Add a tag end offset.
+          local _, EndOffset = textCopy:find(tagPattern);
+          RichTextTagIndices[index].EndOffset = Pointer + EndOffset;
+          
+          -- Remove the tag from the open tag table.
+          table.remove(OpenTagIndices, index);
+          break;
+          
+        end
+        
+      end
+      
+    else
+      
+      -- Get the tag start offset.
+      local StartOffset = Pointer;
+      local Attributes = FirstSpaceIndex and TagText:sub(FirstSpaceIndex + 1) or "";
+      table.insert(RichTextTagIndices, {
+        Name = Name;
+        Attributes = Attributes;
+        StartOffset = Pointer
+      });
+      table.insert(OpenTagIndices, #RichTextTagIndices);
+      
+    end
+    
+    -- Remove the tag from our copy.
+    local _, PointerUpdate = textCopy:find(tagPattern);
+    Pointer += PointerUpdate - 1;
+    textCopy = textCopy:sub(PointerUpdate);
+    
+  end
+  
+  -- 
+  Pointer = 1;
+  local MessageParts = {};
+  repeat
+    
+    -- Check if there's rich text missing.
+    Line.Text = text;
+    local RichTextAdditions = 0;
+    for i = #RichTextTagIndices, 1, -1 do
+      
+      local TagInfo = RichTextTagIndices[i];
+      if TagInfo.StartOffset < Pointer and TagInfo.EndOffset >= Pointer then
 
-    Line.Text = Line.Text .. " " .. word;
-
-    if not Divisions[Page] then Divisions[Page] = {}; end;
-
-    if Line.TextFits then
-
-      table.insert(Divisions[Page],word);
-      Divisions[Page].FullText = Line.Text;
-
-    elseif not Divisions[Page][1] then
-
-      Line.Text = "";
-      for _, letter in ipairs(word:split("")) do
-
-        Line.Text = Line.Text .. letter;
-        if not Line.TextFits then
-
-          -- Remove the letter from the text
-          Line.Text = Line.Text:sub(1,string.len(Line.Text)-1);
-          table.insert(Divisions[Page], Line.Text);
-          Divisions[Page].FullText = Line.Text;
-
-          -- Take it from the top
-          Page = Page + 1;
-          Divisions[Page] = {};
-          Line.Text = letter;
-
-        end;
+        Line.Text = "<" .. TagInfo.Name .. ((TagInfo.Attributes ~= "" and (" " .. TagInfo.Attributes)) or "") .. ">" .. Line.Text;
 
       end;
 
-      table.insert(Divisions[Page], Line.Text);
-      Divisions[Page].FullText = Line.Text;
-
-    else
-
-      Page = Page + 1;
+    end
+    
+    -- Check if the message fits without us having to do anything.
+    if not Line.TextFits then
+      
+      -- Check if the message fits without the last word of the message.
+      while not Line.TextFits do
+        
+        -- Get the space that is the closest to the end of the message.
+        local LastSpaceIndex = Line.Text:match("^.*() ");
+        if not LastSpaceIndex then
+          
+          break;
+          
+        end;
+        
+        -- Reform the message without that word.
+        Line.Text = Line.Text:sub(1, LastSpaceIndex - 1);
+        
+      end;
+      
+      -- Check if there are any rich text tags we need to add.
+      Pointer += Line.Text:len();
+      for i = #RichTextTagIndices, 1, -1 do
+        
+        if RichTextTagIndices[i].StartOffset < Pointer and RichTextTagIndices[i].EndOffset >= Pointer then
+          
+          local EndTag = "</" .. RichTextTagIndices[i].Name .. ">";
+          Line.Text = Line.Text .. EndTag;
+          RichTextAdditions += EndTag:len();
+          
+        elseif RichTextTagIndices[i].StartOffset > Pointer then
+          
+          break;
+          
+        end;
+        
+      end
 
     end;
+    
+    -- Add the words to the table.
+    table.insert(MessageParts, Line.Text);
+    
+    -- Subtract what we added to the table.
+    text = text:sub(Line.Text:len() - RichTextAdditions + 1);
 
-  end;
+  until text == "";
 
   Line:Destroy();
 
-  return Divisions;
+  return MessageParts;
 
 end;
 
@@ -448,7 +531,7 @@ function DialogueModule.ReadDialogue(npc: Model)
         for index, page in ipairs(DividedText) do
 
           -- Now we can get the new text
-          FullMessageText = page.FullText;
+          FullMessageText = page;
           TextContainer.Line.Text = FullMessageText;
           for count = 0, TextContainer.Line.Text:len() do
 
@@ -463,7 +546,7 @@ function DialogueModule.ReadDialogue(npc: Model)
 
           end;
 
-          if DividedText[index+1] and NPCTalking then
+          if DividedText[index + 1] and NPCTalking then
 
             -- Wait for the player to click
             ThemeDialogueContainer.ClickToContinue.Visible = true;

--- a/client/DialogueClientScript/API/GUI.lua
+++ b/client/DialogueClientScript/API/GUI.lua
@@ -7,46 +7,75 @@ local GUIModule = {
   CurrentTheme = script.CurrentTheme;
 };
 
-local DefaultThemeName = nil;
-function GUIModule.GetDefaultThemeName(): string
+local DefaultThemes: {
+  [number]: {
+    MinimumViewportWidth: number;
+    MinimumViewportHeight: number;
+    ThemeName: string;
+  }  
+}? = nil;
+function GUIModule.GetDefaultThemeName(viewportWidth: number, viewportHeight: number): string
 
   -- Check if the theme is in the cache
-  if DefaultThemeName then
-
-    return DefaultThemeName;
-
+  if not DefaultThemes then
+    
+    DefaultThemes = RemoteConnections.GetDefaultThemes:InvokeServer();
+    
   end;
+  assert(DefaultThemes, "[Dialogue Maker] Couldn't get default themes from the server.");
 
-  -- Call up the server.
-  return RemoteConnections.GetDefaultTheme:InvokeServer();
+  local DefaultThemeName;
+  for _, themeInfo in ipairs(DefaultThemes) do
+    
+    if viewportWidth >= themeInfo.MinimumViewportWidth and viewportHeight >= themeInfo.MinimumViewportHeight then
+      
+      DefaultThemeName = themeInfo.ThemeName;
+      
+    end
+    
+  end
+  
+  return DefaultThemeName;
 
 end;
 
 function GUIModule.CreateNewDialogueGui(theme: string?): ScreenGui
-
+  
   -- Check if we have the theme
   local ThemeFolder = script.Parent.Parent.Themes;
-  local ThemeName = (theme ~= "" and theme) or GUIModule.GetDefaultThemeName();
-  local DialogueGui = ThemeName and ThemeFolder:FindFirstChild(ThemeName);
+  local DialogueGui = ThemeFolder:FindFirstChild(theme);
+  if theme and not DialogueGui then
+    
+    if theme ~= "" then
+      
+      warn("[Dialogue Maker]: Can't find theme \"" .. theme .. "\" in the Themes folder of the DialogueClientScript. Using default theme...");
+
+    end
+
+    local ScreenGuiTest = Instance.new("ScreenGui");
+    ScreenGuiTest.Parent = game:GetService("Players").LocalPlayer:WaitForChild("PlayerGui");
+    local ViewportSize = ScreenGuiTest.AbsoluteSize;
+    local DefaultThemeName = GUIModule.GetDefaultThemeName(ViewportSize.X, ViewportSize.Y);
+    ScreenGuiTest:Destroy();
+    DialogueGui = ThemeFolder:FindFirstChild(DefaultThemeName);
+    
+  end
+  
   if not DialogueGui then
 
     error("[Dialogue Maker]: There isn't a default theme", 0);
 
-  elseif ThemeName == DefaultThemeName and theme and theme ~= DefaultThemeName then
-
-    warn("[Dialogue Maker]: Can't find theme \"" .. theme .. "\" in the Themes folder of the DialogueClientScript. Using default theme...");
-
   end
-
+  
   -- Return the theme
   return DialogueGui:Clone();
 
 end;
 
 ReplicatedStorage:WaitForChild("DialogueMakerRemoteConnections").ChangeTheme.OnClientInvoke = function(themeName)
-
+  
   script.CurrentTheme.Value = GUIModule.CreateNewDialogueGui(themeName);
-
+  
 end;
 
 return GUIModule;

--- a/server/DialogueServerScript.lua
+++ b/server/DialogueServerScript.lua
@@ -28,7 +28,7 @@ RemoteConnections.GetNPCDialogue.OnServerInvoke = function(player)
 
 end;
 
-RemoteConnections.GetDefaultTheme.OnServerInvoke = function(player)
+RemoteConnections.GetDefaultThemes.OnServerInvoke = function(player)
 
   return Settings.DefaultTheme;
 

--- a/server/DialogueServerScript/Settings.lua
+++ b/server/DialogueServerScript/Settings.lua
@@ -1,18 +1,42 @@
-return {
+local Settings: {
+  DefaultTheme: {
+    [number]: {
+      MinimumViewportWidth: number;
+      MinimumViewportHeight: number;
+      ThemeName: string;
+    }
+  };
+  ShowResponsesAfterMessageFinished: boolean;
+  DefaultClickSound: number;
+  MinimumDistanceFromCharacter: number;
+  KeybindsEnabled: boolean;
+  DefaultChatTriggerKey: Enum.KeyCode;
+  DefaultChatTriggerKeyGamepad: Enum.KeyCode;
+  DefaultChatContinueKey: Enum.KeyCode;
+  DefaultChatContinueKeyGamepad: Enum.KeyCode;
+} = {
 	
-	-- [ Theme Settings ] --
-	DefaultTheme = "BigAndBoldDialogue"; -- This is the default theme that will be used when talking with NPCs
+  -- [ Theme Settings ] --
+  DefaultTheme = {
+    {
+      MinimumViewportWidth = 0,
+      MinimumViewportHeight = 0,
+      ThemeName = "BigAndBoldDialogue"
+    }
+  }; -- This is the default theme that will be used when talking with NPCs
 	
-	-- [ Response Settings ] --
-	ShowResponsesAfterMessageFinished = true; -- Prevents the player from selecting responses without first viewing the dialogue
-	DefaultClickSound = 0; -- Replace this with an audio ID that'll play every time a player continues a conversation or selects a response. Replace with 0 to not play any sound.
+  -- [ Response Settings ] --
+  ShowResponsesAfterMessageFinished = true; -- Prevents the player from selecting responses without first viewing the dialogue
+  DefaultClickSound = 0; -- Replace this with an audio ID that'll play every time a player continues a conversation or selects a response. Replace with 0 to not play any sound.
 	
-	-- [ Chat Triggers and Keybinds ] --
-	MinimumDistanceFromCharacter = 10; -- Minimum distance from a character required for keybinds should work
-	KeybindsEnabled = true; -- Whether or not keybinds should work
-	DefaultChatTriggerKey = Enum.KeyCode.F; -- Keyboard keybind to start a conversation with an NPC
-	DefaultChatTriggerKeyGamepad = Enum.KeyCode.ButtonX; -- Gamepad keybind to start a conversation with an NPC
-	DefaultChatContinueKey = Enum.KeyCode.F; -- Keyboard keybind to continue a conversation with an NPC
-	DefaultChatContinueKeyGamepad = Enum.KeyCode.ButtonA; -- Gamepad keybind to continue a conversation with an NPC
+  -- [ Chat Triggers and Keybinds ] --
+  MinimumDistanceFromCharacter = 10; -- Minimum distance from a character required for keybinds should work
+  KeybindsEnabled = true; -- Whether or not keybinds should work
+  DefaultChatTriggerKey = Enum.KeyCode.F; -- Keyboard keybind to start a conversation with an NPC
+  DefaultChatTriggerKeyGamepad = Enum.KeyCode.ButtonX; -- Gamepad keybind to start a conversation with an NPC
+  DefaultChatContinueKey = Enum.KeyCode.F; -- Keyboard keybind to continue a conversation with an NPC
+  DefaultChatContinueKeyGamepad = Enum.KeyCode.ButtonA; -- Gamepad keybind to continue a conversation with an NPC
 	
 };
+
+return Settings;


### PR DESCRIPTION
# ✨ New features
## ⏸️ Wait tags
You can now pause mid-message by using "[/wait time=`any number`]", where "`any number`" is...well, any number! For example, "Hello, [/wait time=0.5]Christian!" waits 0.5 seconds before saying "Christian". 

Sponsored by [extravent3](https://devforum.roblox.com/u/extravent3/summary). [[commit]](https://github.com/Beastslash/roblox-dialogue-maker/pull/65/commits/a6788432beb551ab83a73ab0f7fa2b86c2d8fdcc) 

## 🖼️ Conditional themes [BREAKING CHANGE]
I'm personally not a fan of using Scale everywhere because it can overstretch themes and not follow my intended design. So, I added [a couple of server settings](https://github.com/Beastslash/roblox-dialogue-maker/blob/fbf82b634415cd4653ff55084b76cdc24d5bd3b4/server/DialogueServerScript/Settings.lua) to change the default theme based on the minimum viewport width and minimum viewport height. I was inspired by "@media screen" in CSS. 

Here's an example where Dialogue Maker defaults to BareBonesDialogue, but shifts the default to BigAndBoldDialogue when the client's viewport width is at least 320 pixels:
```lua
DefaultTheme = {
  {
    MinimumViewportWidth = 0,
    MinimumViewportHeight = 0,
    ThemeName = "BareBonesDialogue"
  },
  {
    MinimumViewportWidth = 320,
    MinimumViewportHeight = 0,
    ThemeName = "BigAndBoldDialogue"
  }
};
```

Sponsored by [extravent3](https://devforum.roblox.com/u/extravent3/summary). [[commit]](https://github.com/Beastslash/roblox-dialogue-maker/pull/65/commits/fbf82b634415cd4653ff55084b76cdc24d5bd3b4)

# 🔨 Bug fixes
* Rich text should now work on multiple pages. <br />[[commit 1]](https://github.com/Beastslash/roblox-dialogue-maker/pull/65/commits/d60f323f678bda5764c9fed4d75195f9f6704a57) [[commit 2]](https://github.com/Beastslash/roblox-dialogue-maker/pull/65/commits/28f74667bbf4e5f0b5a86c6ece0b660ceb692cb6)

# 🧹 Code review
* **[BREAKING CHANGE]** Removed DialogueSettings table checks. <br />[[commit 1]](https://github.com/Beastslash/roblox-dialogue-maker/pull/65/commits/94f70a946d2d68ee881f58bab308a9ca3ba68764) [[commit 2]](https://github.com/Beastslash/roblox-dialogue-maker/pull/65/commits/078629bb8460466ada3f880913ff25463d570ade)

# ⬆️ Migrating to v4.0.0
## Fix scripts
You need to press the "Fix Scripts" button after updating the plugin. This will replace the internal scripts with the new versions.

## Rename "GetDefaultTheme" to "GetDefaultThemes"
Look in the "DialogueMakerRemoteConnections" folder in ReplicatedStorage for "GetDefaultTheme". Rename it to "GetDefaultThemes".

## Update NPC settings
Copy your NPC settings into a notepad, delete the NPC settings script, reopen the NPC settings, then update the necessary settings.

## Update server settings
Replace your "DefaultTheme" server setting value with:
```lua
DefaultTheme = {
  {
    MinimumViewportWidth = 0,
    MinimumViewportHeight = 0,
    ThemeName = "BigAndBoldDialogue"
  }
};
```

Change the theme name as necessary.